### PR TITLE
Busybox ssl cert fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ FROM busybox:latest
 WORKDIR /app
 COPY --from=builder  /app/crobat_client /app/crobat_client
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+RUN ln -s /etc/ssl/certs/ca-certificates.crt /etc/ssl/cert.pem
 ENTRYPOINT ["/app/crobat_client"]


### PR DESCRIPTION
Busybox didn't seem to be picking up ca-certifcates copied from the Alpine builder container- symlinking `/etc/ssl/cert.pem/` appears to fix this. Fix for issue #2  